### PR TITLE
updates to enable latest openfl and gandlf

### DIFF
--- a/Task_1/fets_challenge/experiment.py
+++ b/Task_1/fets_challenge/experiment.py
@@ -254,7 +254,7 @@ def run_challenge_experiment(aggregation_function,
                              save_checkpoints=True,
                              restore_from_checkpoint_folder=None, 
                              include_validation_with_hausdorff=True,
-                             use_pretrained_model=True):
+                             use_pretrained_model=False):
 
     fx.init('fets_challenge_workspace')
     
@@ -367,18 +367,18 @@ def run_challenge_experiment(aggregation_function,
             'time': [],
             'convergence_score': [],
             'round_dice': [],
-            'dice_label_0': [],
-            'dice_label_1': [],
-            'dice_label_2': [],
-            'dice_label_4': [],
+            # 'dice_label_0': [],
+            # 'dice_label_1': [],
+            # 'dice_label_2': [],
+            # 'dice_label_4': [],
         }
-    if include_validation_with_hausdorff:
-        experiment_results.update({
-            'hausdorff95_label_0': [],
-            'hausdorff95_label_1': [],
-            'hausdorff95_label_2': [],
-            'hausdorff95_label_4': [],
-            })
+    # if include_validation_with_hausdorff:
+    #     experiment_results.update({
+    #         'hausdorff95_label_0': [],
+    #         'hausdorff95_label_1': [],
+    #         'hausdorff95_label_2': [],
+    #         'hausdorff95_label_4': [],
+    #         })
         
 
     if restore_from_checkpoint_folder is None:
@@ -496,15 +496,15 @@ def run_challenge_experiment(aggregation_function,
        
         # get the performace validation scores for the round
         round_dice = get_metric('valid_dice', round_num, aggregator.tensor_db)
-        dice_label_0 = get_metric('valid_dice_per_label_0', round_num, aggregator.tensor_db)
-        dice_label_1 = get_metric('valid_dice_per_label_1', round_num, aggregator.tensor_db)
-        dice_label_2 = get_metric('valid_dice_per_label_2', round_num, aggregator.tensor_db)
-        dice_label_4 = get_metric('valid_dice_per_label_4', round_num, aggregator.tensor_db)
-        if include_validation_with_hausdorff:
-            hausdorff95_label_0 = get_metric('valid_hd95_per_label_0', round_num, aggregator.tensor_db)
-            hausdorff95_label_1 = get_metric('valid_hd95_per_label_1', round_num, aggregator.tensor_db)
-            hausdorff95_label_2 = get_metric('valid_hd95_per_label_2', round_num, aggregator.tensor_db)
-            hausdorff95_label_4 = get_metric('valid_hd95_per_label_4', round_num, aggregator.tensor_db)
+        # dice_label_0 = get_metric('valid_dice_per_label_0', round_num, aggregator.tensor_db)
+        # dice_label_1 = get_metric('valid_dice_per_label_1', round_num, aggregator.tensor_db)
+        # dice_label_2 = get_metric('valid_dice_per_label_2', round_num, aggregator.tensor_db)
+        # dice_label_4 = get_metric('valid_dice_per_label_4', round_num, aggregator.tensor_db)
+        # if include_validation_with_hausdorff:
+        #     hausdorff95_label_0 = get_metric('valid_hd95_per_label_0', round_num, aggregator.tensor_db)
+        #     hausdorff95_label_1 = get_metric('valid_hd95_per_label_1', round_num, aggregator.tensor_db)
+        #     hausdorff95_label_2 = get_metric('valid_hd95_per_label_2', round_num, aggregator.tensor_db)
+        #     hausdorff95_label_4 = get_metric('valid_hd95_per_label_4', round_num, aggregator.tensor_db)
 
         # update best score
         if best_dice < round_dice:
@@ -537,30 +537,30 @@ def run_challenge_experiment(aggregation_function,
         summary = '"**** END OF ROUND {} SUMMARY *****"'.format(round_num)
         summary += "\n\tSimulation Time: {} minutes".format(round(total_simulated_time / 60, 2))
         summary += "\n\t(Projected) Convergence Score: {}".format(projected_auc)
-        summary += "\n\tDICE Label 0: {}".format(dice_label_0)
-        summary += "\n\tDICE Label 1: {}".format(dice_label_1)
-        summary += "\n\tDICE Label 2: {}".format(dice_label_2)
-        summary += "\n\tDICE Label 4: {}".format(dice_label_4)
-        if include_validation_with_hausdorff:
-            summary += "\n\tHausdorff95 Label 0: {}".format(hausdorff95_label_0)
-            summary += "\n\tHausdorff95 Label 1: {}".format(hausdorff95_label_1)
-            summary += "\n\tHausdorff95 Label 2: {}".format(hausdorff95_label_2)
-            summary += "\n\tHausdorff95 Label 4: {}".format(hausdorff95_label_4)
+        # summary += "\n\tDICE Label 0: {}".format(dice_label_0)
+        # summary += "\n\tDICE Label 1: {}".format(dice_label_1)
+        # summary += "\n\tDICE Label 2: {}".format(dice_label_2)
+        # summary += "\n\tDICE Label 4: {}".format(dice_label_4)
+        # if include_validation_with_hausdorff:
+        #     summary += "\n\tHausdorff95 Label 0: {}".format(hausdorff95_label_0)
+        #     summary += "\n\tHausdorff95 Label 1: {}".format(hausdorff95_label_1)
+        #     summary += "\n\tHausdorff95 Label 2: {}".format(hausdorff95_label_2)
+        #     summary += "\n\tHausdorff95 Label 4: {}".format(hausdorff95_label_4)
 
 
         experiment_results['round'].append(round_num)
         experiment_results['time'].append(total_simulated_time)
         experiment_results['convergence_score'].append(projected_auc)
         experiment_results['round_dice'].append(round_dice)
-        experiment_results['dice_label_0'].append(dice_label_0)
-        experiment_results['dice_label_1'].append(dice_label_1)
-        experiment_results['dice_label_2'].append(dice_label_2)
-        experiment_results['dice_label_4'].append(dice_label_4)
-        if include_validation_with_hausdorff:
-            experiment_results['hausdorff95_label_0'].append(hausdorff95_label_0)
-            experiment_results['hausdorff95_label_1'].append(hausdorff95_label_1)
-            experiment_results['hausdorff95_label_2'].append(hausdorff95_label_2)
-            experiment_results['hausdorff95_label_4'].append(hausdorff95_label_4)
+        # experiment_results['dice_label_0'].append(dice_label_0)
+        # experiment_results['dice_label_1'].append(dice_label_1)
+        # experiment_results['dice_label_2'].append(dice_label_2)
+        # experiment_results['dice_label_4'].append(dice_label_4)
+        # if include_validation_with_hausdorff:
+        #     experiment_results['hausdorff95_label_0'].append(hausdorff95_label_0)
+        #     experiment_results['hausdorff95_label_1'].append(hausdorff95_label_1)
+        #     experiment_results['hausdorff95_label_2'].append(hausdorff95_label_2)
+        #     experiment_results['hausdorff95_label_4'].append(hausdorff95_label_4)
         logger.info(summary)
 
         if save_checkpoints:

--- a/Task_1/fets_challenge/inference.py
+++ b/Task_1/fets_challenge/inference.py
@@ -81,7 +81,8 @@ def generate_validation_csv(data_path, validation_csv_filename, working_dir):
                               0.0,
                               'placeholder',
                               training_and_validation=False)
-    validation_csv_dict.to_csv(os.path.join(working_dir, 'validation_paths.csv'),index=False)
+    os.makedirs(os.path.join(working_dir, 'inference_col'), exist_ok=True)
+    validation_csv_dict.to_csv(os.path.join(working_dir, 'inference_col', 'valid.csv'),index=False)
 
 def replace_initializations(done_replacing, array, mask, replacement_value, initialization_value):
     """
@@ -228,12 +229,13 @@ def model_outputs_to_disc(data_path,
     
     # Update the plan if necessary
     plan = fx.update_plan(overrides)
-    plan.config['task_runner']['settings']['fets_config_dict']['save_output'] = True
-    plan.config['task_runner']['settings']['fets_config_dict']['output_dir'] = output_path
+    plan.config['task_runner']['settings']['gandlf_config']['save_output'] = True
+    plan.config['task_runner']['settings']['gandlf_config']['output_dir'] = output_path
 
     # overwrite datapath value for a single 'InferenceCol' collaborator
-    plan.cols_data_paths['InferenceCol'] = data_path
-    
+    # plan.cols_data_paths['InferenceCol'] = data_path
+    plan.cols_data_paths['InferenceCol'] = 'inference_col'
+
     # get the inference data loader
     data_loader = copy(plan).get_data_loader('InferenceCol')
 

--- a/Task_1/openfl-workspace/fets_challenge_workspace/plan/plan.yaml
+++ b/Task_1/openfl-workspace/fets_challenge_workspace/plan/plan.yaml
@@ -92,9 +92,10 @@ task_runner :
       track_memory_usage: false
       verbose: false
       version:
-        maximum: 0.0.14
+        maximum: 0.1.0
         minimum: 0.0.14
       weighted_loss: true
+      modality: rad
 
 
 network :

--- a/Task_1/setup.py
+++ b/Task_1/setup.py
@@ -28,8 +28,8 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'openfl @ git+https://github.com/intel/openfl.git@v1.5.1',
-        'GANDLF @ git+https://github.com/CBICA/GaNDLF.git@0.0.17',
+        'openfl @ git+https://github.com/securefederatedai/openfl.git@kta-intel/fets-2024-patch-1',
+        'GANDLF @ git+https://github.com/CBICA/GaNDLF.git@0.1.0',
         'fets @ git+https://github.com/FETS-AI/Algorithms.git@fets_challenge',
     ],
     python_requires='>=3.9',


### PR DESCRIPTION
Summary of changes:
`setup.py`
- install latest `openfl` (dev branch + patch commit to enable inference) and `GaNDLF`

`plan.yaml`
- update accepted versions
- add `modality` setting (required by `GaNDLF`)

`inference.py`
- create a new dir in workspace for inference and pass this path to plan (better convention to be ingested by the dataloader)
- minor update to setting
- NOTE: this is the step that required the openfl patch. openfl's gandalf dataloader is hard coded to check for a `train.csv` file

`experiment.py`
- remove all notices of `per_label` or else it will interfere with how data is being handled (empty values leading  to uneven rows, etc.)